### PR TITLE
Reset spies before uiFromState test

### DIFF
--- a/src/ui-from-state/index.test.js
+++ b/src/ui-from-state/index.test.js
@@ -6,14 +6,20 @@ const { spy } = require('simple-spy')
 const arenaStubReturn = Symbol('arenaStub')
 const arenaStub = () => arenaStubReturn
 const arenaSpy = spy(arenaStub)
-test.afterEach(() => arenaSpy.reset())
 mock('./arena', arenaSpy)
 
 const winMessageStubReturn = Symbol('winMessageStub')
 const winMessageStub = () => winMessageStubReturn
 const winMessageSpy = spy(winMessageStub)
-test.afterEach(() => winMessageSpy.reset())
 mock('./win-message', winMessageSpy)
+
+test.beforeEach(() => {
+  [
+    winMessageSpy,
+    arenaSpy
+  ]
+  .forEach(spy => spy.reset())
+})
 
 const uiFromState = require('.')
 


### PR DESCRIPTION
Because after seems to not prevent
cross-test contamination (why?)