### PR TITLE
Symbols as constants (closes #150)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@cycle/xstream-run": "^3.1.0",
     "cuid": "^1.3.8",
     "ramda": "^0.22.1",
+    "regalia": "^1.0.2",
     "urify": "^2.1.0",
     "xstream": "^8.0.0"
   },
@@ -53,6 +54,8 @@
     "ava": "^0.16.0",
     "budo": "^9.2.1",
     "codecov": "^1.0.1",
+    "equals-regalia": "^1.0.1",
+    "is-regalia": "^1.0.1",
     "is-subset": "^0.1.1",
     "mock-require": "^2.0.0",
     "npm-run-all": "^3.1.1",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,23 +1,25 @@
-const constants = {
-  gameStatus: {
-    idle: Symbol.for('gameStatus.idle'),
-    afoot: Symbol.for('gameStatus.afoot'),
-    ended: Symbol.for('gameStatus.ended')
-  },
-  actionNames: {
-    startGame: Symbol.for('actionNames.startGame'),
-    hide: Symbol.for('actionNames.hide'),
-    unhide: Symbol.for('actionNames.unhide'),
-    shoot: Symbol.for('actionNames.shoot')
-  },
-  actionPayloadKeys: {
-    player: Symbol.for('actionPayloadKeys.player')
-  },
-  players: {
-    leftPlayer: Symbol.for('players.leftPlayer'),
-    rightPlayer: Symbol.for('players.rightPlayer')
-  }
-}
+const regalia = require('regalia')
+
+const constants = regalia({
+  gameStatus: [
+    'idle',
+    'afoot',
+    'ended'
+  ],
+  actionNames: [
+    'startGame',
+    'hide',
+    'unhide',
+    'shoot'
+  ],
+  actionPayloadKeys: [
+    'player'
+  ],
+  players: [
+    'leftPlayer',
+    'rightPlayer'
+  ]
+})
 
 Object.freeze(constants)
 module.exports = constants

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,21 +1,21 @@
 const constants = {
   gameStatus: {
-    idle: 'IDLE',
-    afoot: 'AFOOT',
-    ended: 'ENDED'
+    idle: Symbol.for('gameStatus.idle'),
+    afoot: Symbol.for('gameStatus.afoot'),
+    ended: Symbol.for('gameStatus.ended')
   },
   actionNames: {
-    startGame: 'START_GAME',
-    hide: 'HIDE',
-    unhide: 'UNHIDE',
-    shoot: 'SHOOT'
+    startGame: Symbol.for('actionNames.startGame'),
+    hide: Symbol.for('actionNames.hide'),
+    unhide: Symbol.for('actionNames.unhide'),
+    shoot: Symbol.for('actionNames.shoot')
   },
   actionPayloadKeys: {
-    player: 'PLAYER'
+    player: Symbol.for('actionPayloadKeys.player')
   },
   players: {
-    leftPlayer: 'LEFT_PLAYER',
-    rightPlayer: 'RIGHT_PLAYER'
+    leftPlayer: Symbol.for('players.leftPlayer'),
+    rightPlayer: Symbol.for('players.rightPlayer')
   }
 }
 

--- a/src/constants.test.js
+++ b/src/constants.test.js
@@ -1,29 +1,35 @@
 const constants = require('./constants')
 const { test } = require('ava')
+const isRegalia = require('is-regalia')
+const equalsRegalia = require('equals-regalia')
 
-test('exported object deep equality assertion', t => {
-  const expectedConstants = {
-    gameStatus: {
-      idle: Symbol.for('gameStatus.idle'),
-      afoot: Symbol.for('gameStatus.afoot'),
-      ended: Symbol.for('gameStatus.ended')
-    },
-    actionNames: {
-      startGame: Symbol.for('actionNames.startGame'),
-      hide: Symbol.for('actionNames.hide'),
-      unhide: Symbol.for('actionNames.unhide'),
-      shoot: Symbol.for('actionNames.shoot')
-    },
-    actionPayloadKeys: {
-      player: Symbol.for('actionPayloadKeys.player')
-    },
-    players: {
-      leftPlayer: Symbol.for('players.leftPlayer'),
-      rightPlayer: Symbol.for('players.rightPlayer')
-    }
+test('exports a regalia tree', t => {
+  t.true(isRegalia(constants))
+})
+
+test('tree deep equality', t => {
+  const definition = {
+    gameStatus: [
+      'idle',
+      'afoot',
+      'ended'
+    ],
+    actionNames: [
+      'startGame',
+      'hide',
+      'unhide',
+      'shoot'
+    ],
+    actionPayloadKeys: [
+      'player'
+    ],
+    players: [
+      'leftPlayer',
+      'rightPlayer'
+    ]
   }
 
-  t.deepEqual(constants, expectedConstants)
+  t.true(equalsRegalia(constants, definition))
 })
 
 test('exported object is frozen', t => {

--- a/src/constants.test.js
+++ b/src/constants.test.js
@@ -4,22 +4,22 @@ const { test } = require('ava')
 test('exported object deep equality assertion', t => {
   const expectedConstants = {
     gameStatus: {
-      idle: 'IDLE',
-      afoot: 'AFOOT',
-      ended: 'ENDED'
+      idle: Symbol.for('gameStatus.idle'),
+      afoot: Symbol.for('gameStatus.afoot'),
+      ended: Symbol.for('gameStatus.ended')
     },
     actionNames: {
-      startGame: 'START_GAME',
-      hide: 'HIDE',
-      unhide: 'UNHIDE',
-      shoot: 'SHOOT'
+      startGame: Symbol.for('actionNames.startGame'),
+      hide: Symbol.for('actionNames.hide'),
+      unhide: Symbol.for('actionNames.unhide'),
+      shoot: Symbol.for('actionNames.shoot')
     },
     actionPayloadKeys: {
-      player: 'PLAYER'
+      player: Symbol.for('actionPayloadKeys.player')
     },
     players: {
-      leftPlayer: 'LEFT_PLAYER',
-      rightPlayer: 'RIGHT_PLAYER'
+      leftPlayer: Symbol.for('players.leftPlayer'),
+      rightPlayer: Symbol.for('players.rightPlayer')
     }
   }
 

--- a/src/start-game-actions-from-dom-source.test.js
+++ b/src/start-game-actions-from-dom-source.test.js
@@ -10,7 +10,7 @@ const {
 } = require('./constants')
 const actionNameKey = require('./action').nameKey
 
-test(`emits '${Symbol.keyFor(startGame)}' for clicks on \`startGameButton\`’s exported selector`, t => {
+test(`emits \`${String(startGame)}\` for clicks on \`startGameButton\`’s exported selector`, t => {
   t.plan(1)
 
   const { selector } = require('./vtree-from-state/start-game-button')

--- a/src/start-game-actions-from-dom-source.test.js
+++ b/src/start-game-actions-from-dom-source.test.js
@@ -10,7 +10,7 @@ const {
 } = require('./constants')
 const actionNameKey = require('./action').nameKey
 
-test(`emits '${startGame}' for clicks on \`startGameButton\`’s exported selector`, t => {
+test(`emits '${Symbol.keyFor(startGame)}' for clicks on \`startGameButton\`’s exported selector`, t => {
   t.plan(1)
 
   const { selector } = require('./vtree-from-state/start-game-button')

--- a/src/state-machine.test.js
+++ b/src/state-machine.test.js
@@ -118,15 +118,15 @@ const testsForActionName = {
   ]
 }
 
-for (const name in testsForActionName) {
+Object.getOwnPropertySymbols(testsForActionName).forEach(name => {
   const tests = testsForActionName[name]
   tests.forEach(({currentState, expectedState, payload}, index) => {
-    test(`action ${name} test ${index}; state: ${stringFromObject(currentState)}; payload: ${stringFromObject(payload)}`, t => {
+    test(`action ${Symbol.keyFor(name)} test ${index}; state: ${stringFromObject(currentState)}; payload: ${stringFromObject(payload)}`, t => {
       const actual = stateMachine(currentState, Object.assign({ [actionNameKey]: name }, payload))
       t.deepEqual(actual, expectedState)
     })
   })
-}
+})
 
 const impossibleStatesForActionName = {
   [startGame]: [
@@ -139,13 +139,13 @@ const impossibleStatesForActionName = {
   ]
 }
 
-for (const name in impossibleStatesForActionName) {
+Object.getOwnPropertySymbols(impossibleStatesForActionName).forEach(name => {
   const states = impossibleStatesForActionName[name]
   states.forEach(state => {
-    test(`${name} throws on impossible state ${stringFromObject(state)}`, t => {
+    test(`${Symbol.keyFor(name)} throws on impossible state ${stringFromObject(state)}`, t => {
       t.throws(
         () => { stateMachine(state, { [actionNameKey]: name }) },
         'Impossible action at current state')
     })
   })
-}
+})

--- a/src/state-machine.test.js
+++ b/src/state-machine.test.js
@@ -121,7 +121,7 @@ const testsForActionName = {
 Object.getOwnPropertySymbols(testsForActionName).forEach(name => {
   const tests = testsForActionName[name]
   tests.forEach(({currentState, expectedState, payload}, index) => {
-    test(`action ${Symbol.keyFor(name)} test ${index}; state: ${stringFromObject(currentState)}; payload: ${stringFromObject(payload)}`, t => {
+    test(`\`${String(name)}\` test ${index}; state: ${stringFromObject(currentState)}; payload: ${stringFromObject(payload)}`, t => {
       const actual = stateMachine(currentState, Object.assign({ [actionNameKey]: name }, payload))
       t.deepEqual(actual, expectedState)
     })
@@ -142,7 +142,7 @@ const impossibleStatesForActionName = {
 Object.getOwnPropertySymbols(impossibleStatesForActionName).forEach(name => {
   const states = impossibleStatesForActionName[name]
   states.forEach(state => {
-    test(`${Symbol.keyFor(name)} throws on impossible state ${stringFromObject(state)}`, t => {
+    test(`\`${String(name)}\` throws on impossible state ${stringFromObject(state)}`, t => {
       t.throws(
         () => { stateMachine(state, { [actionNameKey]: name }) },
         'Impossible action at current state')

--- a/src/vtree-from-state/win-message.test.js
+++ b/src/vtree-from-state/win-message.test.js
@@ -16,7 +16,7 @@ const possibleArgs = [
 const withPossibleArg = arg => {
   const winner = arg === leftPlayer ? 'Left' : 'Right'
   const expected = `${winner} won!`
-  test(`given '${Symbol.keyFor(arg)}' returns '${expected}'`, t => {
+  test(`given \`${String(arg)}\` returns '${expected}'`, t => {
     const actual = winMessage(arg)
     t.is(actual, expected)
   })

--- a/src/vtree-from-state/win-message.test.js
+++ b/src/vtree-from-state/win-message.test.js
@@ -16,7 +16,7 @@ const possibleArgs = [
 const withPossibleArg = arg => {
   const winner = arg === leftPlayer ? 'Left' : 'Right'
   const expected = `${winner} won!`
-  test(`given '${arg}' returns '${expected}'`, t => {
+  test(`given '${Symbol.keyFor(arg)}' returns '${expected}'`, t => {
     const actual = winMessage(arg)
     t.is(actual, expected)
   })


### PR DESCRIPTION
I'm not sure about this. I like the idea. Yet, the
implementations is not perfect.

For one, you just can't `for in` or `for of` over symbol-keys!
So I had to change that to use `Object.getOwnPropertySymbols`
and `forEach` over that. Not a big deal, though. Kinda clunky I
feel it is.

Another issue is that now for dynamically generated test names
instead of
'test FOO_BAR_BAZ 4 with state...'
we have
'test actionNames.fooBarBaz 4 with state...'
or something like that.

Please look at the tests outputs. You may wish to do that
locally because then you can use the `ava -s` option, for
sorted output (because tests run serially).
`npm-run ava -sv` is the complete command.